### PR TITLE
Wait for EOF

### DIFF
--- a/src/JsonRPC/HttpClient.php
+++ b/src/JsonRPC/HttpClient.php
@@ -273,9 +273,17 @@ class HttpClient
         }
         stream_set_blocking($stream, false);
 
-        $metadata = stream_get_meta_data($stream);
+        $content = [];
+        do {
+            $content[] = stream_get_contents($stream);
+            $metadata = stream_get_meta_data($stream);
+
+            //sleep a little while to transfer new data into stream
+            usleep(3000);
+        } while (false === $metadata['eof']);
+
         $headers = $metadata['wrapper_data'];
-        $response = json_decode(stream_get_contents($stream), true);
+        $response = json_decode(implode('', $content), true);
         
         fclose($stream);
 


### PR DESCRIPTION
We use non-blocking stream that doesn't wait for EOF.
Now we loop till EOF.
Hopefully this won't break the things fixed with usage of non-blocking
streams.